### PR TITLE
Primitive type field access

### DIFF
--- a/src/main/java/com/github/javalbert/reflection/ClassAccess.java
+++ b/src/main/java/com/github/javalbert/reflection/ClassAccess.java
@@ -14,6 +14,13 @@ package com.github.javalbert.reflection;
 
 public interface ClassAccess<T> {
 	int fieldIndex(String name);
-	
-	int getIntField(T object, int index);
+
+	boolean getBooleanField(T object, int fieldIndex);
+	byte getByteField(T object, int fieldIndex);
+	char getCharField(T object, int fieldIndex);
+	double getDoubleField(T object, int fieldIndex);
+	float getFloatField(T object, int fieldIndex);
+	int getIntField(T object, int fieldIndex);
+	long getLongField(T object, int fieldIndex);
+	short getShortField(T object, int fieldIndex);
 }

--- a/src/test/java/com/github/javalbert/reflection/test/ClassAccessTest.java
+++ b/src/test/java/com/github/javalbert/reflection/test/ClassAccessTest.java
@@ -22,13 +22,90 @@ import com.github.javalbert.reflection.ClassAccessFactory;
 
 public class ClassAccessTest {
 	@Test
+	public void getBooleanFieldValueAndVerify() {
+		ClassAccess<Foo> access = ClassAccessFactory.get(Foo.class);
+		Foo object = new Foo();
+		object.setBooleanVal(true);
+		
+		boolean booleanVal = access.getBooleanField(object, access.fieldIndex("booleanVal"));
+		
+		assertThat(booleanVal, equalTo(true));
+	}
+	
+	@Test
+	public void getByteFieldValueAndVerify() {
+		ClassAccess<Foo> access = ClassAccessFactory.get(Foo.class);
+		Foo object = new Foo();
+		object.setByteVal((byte)-21);
+		
+		byte byteal = access.getByteField(object, access.fieldIndex("byteVal"));
+		
+		assertThat(byteal, equalTo((byte)-21));
+	}
+	
+	@Test
+	public void getCharFieldValueAndVerify() {
+		ClassAccess<Foo> access = ClassAccessFactory.get(Foo.class);
+		Foo object = new Foo();
+		object.setCharVal('.');
+		
+		char charVal = access.getCharField(object, access.fieldIndex("charVal"));
+		
+		assertThat(charVal, equalTo('.'));
+	}
+	
+	@Test
+	public void getDoubleFieldValueAndVerify() {
+		ClassAccess<Foo> access = ClassAccessFactory.get(Foo.class);
+		Foo object = new Foo();
+		object.setDoubleVal(0.14753383239666462d);
+		
+		double doubleVal = access.getDoubleField(object, access.fieldIndex("doubleVal"));
+		
+		assertThat(doubleVal, equalTo(0.14753383239666462d));
+	}
+	
+	@Test
+	public void getFloatFieldValueAndVerify() {
+		ClassAccess<Foo> access = ClassAccessFactory.get(Foo.class);
+		Foo object = new Foo();
+		object.setFloatVal(0.27210158f);
+		
+		float floatVal = access.getFloatField(object, access.fieldIndex("floatVal"));
+		
+		assertThat(floatVal, equalTo(0.27210158f));
+	}
+	
+	@Test
 	public void getIntFieldValueAndVerify() {
 		ClassAccess<Foo> access = ClassAccessFactory.get(Foo.class);
 		Foo object = new Foo();
 		object.setIntVal(1);
-		
-		int intVal = access.getIntField(object, 0);
+
+		int intVal = access.getIntField(object, access.fieldIndex("intVal"));
 		
 		assertThat(intVal, equalTo(1));
+	}
+
+	@Test
+	public void getLongFieldValueAndVerify() {
+		ClassAccess<Foo> access = ClassAccessFactory.get(Foo.class);
+		Foo object = new Foo();
+		object.setLongVal(3285927007071017350L);
+
+		long longVal = access.getLongField(object, access.fieldIndex("longVal"));
+		
+		assertThat(longVal, equalTo(3285927007071017350L));
+	}
+	
+	@Test
+	public void getShortFieldValueAndVerify() {
+		ClassAccess<Foo> access = ClassAccessFactory.get(Foo.class);
+		Foo object = new Foo();
+		object.setShortVal((short)-8406);
+
+		short shortVal = access.getShortField(object, access.fieldIndex("shortVal"));
+		
+		assertThat(shortVal, equalTo((short)-8406));
 	}
 }

--- a/src/test/java/com/github/javalbert/reflection/test/Foo.java
+++ b/src/test/java/com/github/javalbert/reflection/test/Foo.java
@@ -12,15 +12,106 @@
  *******************************************************************************/
 package com.github.javalbert.reflection.test;
 
+import com.github.javalbert.reflection.ClassAccess;
+
 public class Foo {
+	public static class FooAccess2 implements ClassAccess<Foo> {
+		@Override
+		public int fieldIndex(String name) {
+			return 0;
+		}
+
+		@Override
+		public boolean getBooleanField(Foo object, int fieldIndex) {
+			return false;
+		}
+
+		@Override
+		public byte getByteField(Foo object, int fieldIndex) {
+			return 0;
+		}
+
+		@Override
+		public char getCharField(Foo object, int fieldIndex) {
+			return 0;
+		}
+
+		@Override
+		public double getDoubleField(Foo object, int fieldIndex) {
+			return 0;
+		}
+
+		@Override
+		public float getFloatField(Foo object, int fieldIndex) {
+			return 0;
+		}
+
+		@Override
+		public int getIntField(Foo object, int fieldIndex) {
+			switch (fieldIndex) {
+				case 5:
+					return object.intVal;
+				default:
+					throw new IllegalArgumentException("No field with index: " + fieldIndex);
+			}
+		}
+
+		@Override
+		public long getLongField(Foo object, int fieldIndex) {
+			switch (fieldIndex) {
+				case 6:
+					return object.longVal;
+				default:
+					throw new IllegalArgumentException("No field with index: " + fieldIndex);
+			}
+		}
+
+		@Override
+		public short getShortField(Foo object, int fieldIndex) {
+			return 0;
+		}
+	}
+	
+	private boolean booleanVal;
+	private byte byteVal;
+	private char charVal;
+	private double doubleVal;
+	private float floatVal;
 	private int intVal;
 	private long longVal;
+	private short shortVal;
 	private String stringVal;
-	private int age;
-	private String stage;
-	private int version;
-	private Double price;
 	
+	public boolean isBooleanVal() {
+		return booleanVal;
+	}
+	public void setBooleanVal(boolean booleanVal) {
+		this.booleanVal = booleanVal;
+	}
+	public byte getByteVal() {
+		return byteVal;
+	}
+	public void setByteVal(byte byteVal) {
+		this.byteVal = byteVal;
+	}
+	public char getCharVal() {
+		return charVal;
+	}
+	public void setCharVal(char charVal) {
+		this.charVal = charVal;
+	}
+	public double getDoubleVal() {
+		return doubleVal;
+	}
+	public void setDoubleVal(double doubleVal) {
+		this.doubleVal = doubleVal;
+	}
+	public float getFloatVal() {
+		return floatVal;
+	}
+	public void setFloatVal(float floatVal) {
+		this.floatVal = floatVal;
+	}
 	public int getIntVal() {
 		return intVal;
 	}
@@ -33,34 +124,16 @@ public class Foo {
 	public void setLongVal(long longVal) {
 		this.longVal = longVal;
 	}
+	public short getShortVal() {
+		return shortVal;
+	}
+	public void setShortVal(short shortVal) {
+		this.shortVal = shortVal;
+	}
 	public String getStringVal() {
 		return stringVal;
 	}
 	public void setStringVal(String stringVal) {
 		this.stringVal = stringVal;
-	}
-	public int getAge() {
-		return age;
-	}
-	public void setAge(int age) {
-		this.age = age;
-	}
-	public String getStage() {
-		return stage;
-	}
-	public void setStage(String stage) {
-		this.stage = stage;
-	}
-	public int getVersion() {
-		return version;
-	}
-	public void setVersion(int version) {
-		this.version = version;
-	}
-	public Double getPrice() {
-		return price;
-	}
-	public void setPrice(Double price) {
-		this.price = price;
 	}
 }


### PR DESCRIPTION
- Make field access method creation general for all primitive types
- Add tests for all primitive types
- Rename int parameter to fieldIndex from index
- Return correct xRETURN opcodes depending on type e.g. use LRETURN for
long to return correct long value instead of truncating to int